### PR TITLE
(#16) handle empty filter strings as noop

### DIFF
--- a/client/filter.go
+++ b/client/filter.go
@@ -15,6 +15,10 @@ type Filter func(f *protocol.Filter) error
 func AgentFilter(f ...string) Filter {
 	return func(pf *protocol.Filter) (err error) {
 		for _, filter := range f {
+			if filter == "" {
+				continue
+			}
+
 			pf.AddAgentFilter(filter)
 		}
 
@@ -26,6 +30,10 @@ func AgentFilter(f ...string) Filter {
 func ClassFilter(f ...string) Filter {
 	return func(pf *protocol.Filter) (err error) {
 		for _, filter := range f {
+			if filter == "" {
+				continue
+			}
+
 			pf.AddClassFilter(filter)
 		}
 
@@ -37,6 +45,10 @@ func ClassFilter(f ...string) Filter {
 func IdentityFilter(f ...string) Filter {
 	return func(pf *protocol.Filter) (err error) {
 		for _, filter := range f {
+			if filter == "" {
+				continue
+			}
+
 			pf.AddIdentityFilter(filter)
 		}
 
@@ -48,6 +60,10 @@ func IdentityFilter(f ...string) Filter {
 func CompoundFilter(f ...string) Filter {
 	return func(pf *protocol.Filter) (err error) {
 		for _, filter := range f {
+			if filter == "" {
+				continue
+			}
+
 			pf.AddCompoundFilter(filter)
 		}
 
@@ -59,6 +75,10 @@ func CompoundFilter(f ...string) Filter {
 func FactFilter(f ...string) Filter {
 	return func(pf *protocol.Filter) (err error) {
 		for _, filter := range f {
+			if filter == "" {
+				continue
+			}
+
 			ff, err := ParseFactFilterString(filter)
 			if err != nil {
 				return err
@@ -81,6 +101,10 @@ func CombinedFilter(f ...string) Filter {
 			parts := strings.Split(filter, " ")
 
 			for _, part := range parts {
+				if part == "" {
+					continue
+				}
+
 				ff, err := ParseFactFilterString(part)
 				if err != nil {
 					pf.AddClassFilter(part)

--- a/client/filter_test.go
+++ b/client/filter_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Client/Filter", func() {
 
 	Describe("FactFilter", func() {
 		It("Should add each filter", func() {
-			err := FactFilter("country=mt", "country=uk")(pf)
+			err := FactFilter("country=mt", "country=uk", "")(pf)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pf.FactFilters()).To(Equal([][3]string{[3]string{"country", "==", "mt"}, [3]string{"country", "==", "uk"}}))
 		})
@@ -41,35 +41,35 @@ var _ = Describe("Client/Filter", func() {
 
 	Describe("AgentFilter", func() {
 		It("Should add each filter", func() {
-			AgentFilter("foo", "/bar/", "baz")(pf)
+			AgentFilter("foo", "/bar/", "baz", "")(pf)
 			Expect(pf.AgentFilters()).To(Equal([]string{"foo", "/bar/", "baz"}))
 		})
 	})
 
 	Describe("ClassFilter", func() {
 		It("Should add each filter", func() {
-			ClassFilter("foo", "/bar/", "baz")(pf)
+			ClassFilter("foo", "/bar/", "baz", "")(pf)
 			Expect(pf.ClassFilters()).To(Equal([]string{"foo", "/bar/", "baz"}))
 		})
 	})
 
 	Describe("IdentityFilter", func() {
 		It("Should add each filter", func() {
-			IdentityFilter("foo", "/bar/", "baz")(pf)
+			IdentityFilter("foo", "/bar/", "baz", "")(pf)
 			Expect(pf.IdentityFilters()).To(Equal([]string{"foo", "/bar/", "baz"}))
 		})
 	})
 
 	Describe("CompoundFilter", func() {
 		It("Should add each filter", func() {
-			CompoundFilter("foo", "/bar/", "baz")(pf)
+			CompoundFilter("foo", "/bar/", "baz", "")(pf)
 			Expect(pf.CompoundFilters()).To(Equal([]string{"foo", "/bar/", "baz"}))
 		})
 	})
 
 	Describe("CombinedFilter", func() {
 		It("Should add each filter", func() {
-			CombinedFilter("foo", "/bar/", "baz", "country=mt")(pf)
+			CombinedFilter("foo", "/bar/", "baz", "country=mt", "")(pf)
 			Expect(pf.ClassFilters()).To(Equal([]string{"foo", "/bar/", "baz"}))
 			Expect(pf.FactFilters()).To(Equal([][3]string{[3]string{"country", "==", "mt"}}))
 		})


### PR DESCRIPTION
With go string vars being "" when empty / zero it's convenient to
hanle empty string as noop else you end up with a whole lot of

    if f != "" { ... }

blocks which just sux