### PR TITLE
(#21) allow the prefix for connection names to be set

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -43,8 +43,9 @@ var _ = Describe("Client", func() {
 
 		fw, _ = choria.NewWithConfig(cfg)
 
-		client, err = New(fw, Connection(conn), Timeout(100*time.Millisecond))
+		client, err = New(fw, Connection(conn), Timeout(100*time.Millisecond), Name("test"))
 		Expect(err).ToNot(HaveOccurred())
+		Expect(client.name).To(Equal("test"))
 	})
 
 	AfterEach(func() {

--- a/client/options.go
+++ b/client/options.go
@@ -44,6 +44,17 @@ func Log(l *logrus.Entry) Option {
 	}
 }
 
+// Name sets a NATS connection name to use, without this random names will be made.
+//
+// This setting is important if you make a daemon that makes many long client connections
+// as each client connection makes Prometheus stats based on the name and you'll be
+// leaking many stats over time
+func Name(n string) Option {
+	return func(c *Client) {
+		c.name = n
+	}
+}
+
 // Connection  Supplies a custom connection, when this is supplied
 // this is the only connection that will be used for the duration
 // of this client for all publishes and replies


### PR DESCRIPTION
When writing daemons that will run for a long time and make
many connections in their life time it will not work to do the
default thing where semi random names are chosen because every
connection will make several prometheus metrics

Overtime these accumulate and will be leaking resources and consuming
many metric resources on the prom server

Now users can set a name to avoid this problem