### PR TITLE
(#25) ensure initial connection will eventually timeout in discovery

### DIFF
--- a/discovery/broadcast/broadcast.go
+++ b/discovery/broadcast/broadcast.go
@@ -82,7 +82,12 @@ func (b *Broadcast) Discover(ctx context.Context, opts ...DiscoverOption) (n []s
 
 	b.log.Debugf("Performing broadcast discovery")
 
-	err = dopts.cl.Request(ctx, dopts.msg, b.handler(dopts))
+	// wrapping it ensures the intial connection does not run forever and inherits the parent ^C handling etc
+	// the +2 gives some additional time to the whole request for network connect time etc
+	rctx, cancel := context.WithTimeout(ctx, dopts.timeout+2)
+	defer cancel()
+
+	err = dopts.cl.Request(rctx, dopts.msg, b.handler(dopts))
 	if err != nil {
 		return n, fmt.Errorf("could not perform request: %s", err)
 	}

--- a/discovery/broadcast/broadcast_test.go
+++ b/discovery/broadcast/broadcast_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Broadcast", func() {
 			f := protocol.NewFilter()
 			f.AddAgentFilter("choria")
 
-			cl.EXPECT().Request(ctx, gomock.Any(), gomock.Any()).Return(nil).Do(func(ctx context.Context, msg *choria.Message, handler client.Handler) {
+			cl.EXPECT().Request(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Do(func(ctx context.Context, msg *choria.Message, handler client.Handler) {
 				Expect(msg.Collective()).To(Equal("test"))
 				Expect(msg.Payload).To(Equal("cGluZw=="))
 


### PR DESCRIPTION
This manages the contexts such that the initial connection to the
middleware has approximately 2 seconds to comple over and above
normal discovery timeout

Eventually we have to make a initial connect context and a request
timeout but for now this will get us over the intial hump